### PR TITLE
feat : 메인 화면 챌린지 + 사용자 순위 + 마이페이지 출석 관련 api 연동 완료 ( 메인 화면 끝 )

### DIFF
--- a/src/components/FriendList/UserList.jsx
+++ b/src/components/FriendList/UserList.jsx
@@ -6,21 +6,7 @@ import {
   useFriendNumStore,
 } from "../../store/useFriendSearchStore";
 import useFetchData from "../../hooks/useFetchData";
-
-// 서버로 부터 사용자 전체 받아오기
-const userList = [
-  { id: 1, nickname: "zoedhj", image: user },
-  { id: 2, nickname: "ywamcgj", image: user },
-  { id: 3, nickname: "qmbvsz", image: user },
-  { id: 4, nickname: "xpjaf", image: user },
-  { id: 5, nickname: "gftrwb", image: user },
-  { id: 6, nickname: "utdjlg", image: user },
-  { id: 7, nickname: "ekzn", image: user },
-  { id: 8, nickname: "bnqozga", image: user },
-  { id: 9, nickname: "vjocb", image: user },
-  { id: 10, nickname: "hwxdp", image: user },
-  { id: 11, nickname: "lymuo", image: user },
-];
+import api from "../../apis/axios";
 
 export const UserList = () => {
   // 서버에서 받아올 유저 리스트
@@ -35,7 +21,7 @@ export const UserList = () => {
   // 친구 수 저장할 함수 가져오기
   const { setNum } = useFriendNumStore();
 
-  // 친구 목록 받아오는 코드 ( 현재 친구가 없어서 mock 데이터로 사용하겠습니다. )
+  // 친구 목록 받아오는 코드
   const { data, isLoading, error } = useFetchData("/friends");
 
   // 받아온 데이터 users state에 저장
@@ -59,6 +45,7 @@ export const UserList = () => {
       setNum(arr.length); // 친구 삭제후 숫자 저장
       setUsers(arr);
       // 서버에게 삭제 요청 보내기
+      api.delete(`/friends/${id}`);
     }
   };
 

--- a/src/components/Main/Challenge.jsx
+++ b/src/components/Main/Challenge.jsx
@@ -4,6 +4,7 @@ import checkButton from "../../images/checkButton.png";
 import checkFillButton from "../../images/checkFillButton.png";
 
 export default function Challenge({
+  id,
   content,
   complete,
   index,
@@ -11,12 +12,12 @@ export default function Challenge({
   allComplete,
 }) {
   return (
-    <Container allComplete={allComplete}>
-      <P onClick={() => handleCheck(index)}>{content}</P>
+    <Container $allComplete={allComplete}>
+      <P onClick={() => handleCheck(index, id)}>{content}</P>
       <div>
         <Image
           src={complete ? checkFillButton : checkButton}
-          onClick={() => handleCheck(index)}
+          onClick={() => handleCheck(index, id)}
         />
       </div>
     </Container>
@@ -39,7 +40,7 @@ const Container = styled.div`
   width: 100%;
   padding: 20px 20px 15px 20px;
   border-radius: ${responsiveSize("31")};
-  color: ${({ allComplete }) => (allComplete ? "white" : "black")};
+  color: ${({ $allComplete }) => ($allComplete ? "white" : "black")};
   justify-content: space-between;
   margin-bottom: 10px;
   position: relative;
@@ -55,11 +56,11 @@ const Container = styled.div`
     width: 100%;
     height: 100%;
     /* 모두 완료했을 때 색깔 변경 */
-    background-color: ${({ theme, allComplete }) =>
-      allComplete ? theme.colors.purple : theme.colors.gray01};
+    background-color: ${({ theme, $allComplete }) =>
+      $allComplete ? theme.colors.purple : theme.colors.gray01};
     z-index: -1;
-    ${({ allComplete }) =>
-      allComplete &&
+    ${({ $allComplete }) =>
+      $allComplete &&
       css`
         animation: ${moveBackground} 0.5s ease-in-out forwards;
       `}

--- a/src/components/Main/ChallengeList.jsx
+++ b/src/components/Main/ChallengeList.jsx
@@ -3,51 +3,76 @@ import Challenge from "./Challenge";
 import styled from "styled-components";
 import { keyframes } from "styled-components";
 import { responsiveSize } from "../../utils/Mediaquery";
-
-const challengeList = [
-  { content: "30분 이상 운동하기" },
-  { content: "물 2L 이상 마시기" },
-  { content: "헬스장 가기" },
-];
+import useFetchData from "../../hooks/useFetchData";
+import api from "../../apis/axios";
 
 export default function ChallengeList() {
-  // 챌린지 완료했는지 체크할 state
-  const [complete, setComplete] = useState({
-    1: true,
-    2: false,
-    3: false,
-  });
+  // 챌린지 정보 담을 state
+  const [challengeList, setChallengeList] = useState([]);
 
   // 모든 챌린지 완료 했는지 체크할 state
   const [allComplete, setAllComplete] = useState(false);
 
+  // 챌린지 3개 가져오기
+  const { data } = useFetchData("/challengeparticipant/today-challenges");
+
   // 챌린지 완료 모양 눌럿을 때 실행할 함수
-  const handleCheck = (idx) => {
+  const handleCheck = async (idx, id) => {
     // 모든 챌린지 완료했으면 챌린지 완료 표시 수정 불가능
     if (allComplete) {
       return;
     }
+    // 체크 모양 눌렀을 때 해당 챌린지 취소, 완료 표시하기
+    let arr = [...challengeList];
 
-    setComplete({ ...complete, [idx]: !complete[idx] });
-  };
+    // 해당 챌린지가 완료인 경우 false로 바꾸기
+    if (arr[idx].completed) {
+      // 사용자에게 미리 업데이트
+      arr[idx].completed = false;
+      // 서버로 데이터 전송
+      try {
+        await api.put(`/challengeparticipant/notcomplete/${id}`);
+      } catch (e) {
+        console.error("에러 발생 " + e);
+      }
+    } else {
+      // 미완료 챌린지를 클릭한 경우 true로 변경
+      arr[idx].completed = true;
+      try {
+        await api.put(`/challengeparticipant/complete/${id}`);
+      } catch (e) {
+        console.error("에러 발생: ", e);
+      }
+    }
 
-  useEffect(() => {
-    if (allComplete) return;
-    if (!Object.values(complete).includes(false)) {
+    //상태 업데이트
+    setChallengeList(arr);
+
+    // 챌린지가 모두 완료되었으면 allComplete 상태 변경
+    if (arr.every((item) => item.completed)) {
       setAllComplete(true);
     }
-  }, [complete]);
+  };
+
+  // 챌린지 가져오고 state에 저장
+  useEffect(() => {
+    if (data) {
+      setChallengeList(data);
+      setAllComplete(data.length === 3 && data.every((item) => item.completed));
+    }
+  }, [data]);
 
   return (
     <Container>
       <SpeechBubble>친구 27명이 성공했어요!</SpeechBubble>
-      {challengeList.map((item, idx) => (
+      {challengeList?.map((item, idx) => (
         <Challenge
           allComplete={allComplete}
-          key={idx}
-          index={idx + 1}
-          content={item.content}
-          complete={complete[idx + 1]}
+          key={item.challengeId}
+          id={item.challengeId}
+          index={idx}
+          content={item.challengeContent}
+          complete={item.completed}
           handleCheck={handleCheck}
         />
       ))}

--- a/src/components/Main/UserList.jsx
+++ b/src/components/Main/UserList.jsx
@@ -1,23 +1,37 @@
 import styled from "styled-components";
 import User from "./User";
-import { bounce } from "./ChallengeList";
 import { SpeechBubble } from "./ChallengeList";
-
-const userList = [
-  { nickname: "연기" },
-  { nickname: "도연" },
-  { nickname: "지현" },
-  { nickname: "박하" },
-  { nickname: "서연" },
-  { nickname: "규희" },
-];
+import useFetchData from "../../hooks/useFetchData";
+import { useUserInfo } from "../../store/useUserInfo";
+import { useEffect, useState } from "react";
 
 export default function UserList() {
+  // 사용자 정보 저장할 배열 state
+  const [userList, setUserList] = useState([]);
+
+  // 나의 순위를 저장할 state
+  const [rank, setRank] = useState(0);
+
+  // 현재 로그인한 정보 가져오기
+  const { user } = useUserInfo();
+
+  // 사용자 랭킹 데이터 서버에서 받아오기
+  const { data } = useFetchData("/challengeparticipant/ranking");
+
+  useEffect(() => {
+    if (data) {
+      setUserList(data);
+      // 받아온 데이터 중 나의 순위 찾아서 저장하기
+      let myRank = data.find((item) => item.userId === user.userId).rank;
+      setRank(myRank);
+    }
+  }, [data]);
+
   return (
     <Container>
-      <SpeechBubble>사용자님은 현재 7위에요!</SpeechBubble>
-      {userList.map((item, idx) => (
-        <User {...item} rank={idx + 1} key={item.nickname} />
+      <SpeechBubble>사용자님은 현재 {rank}위에요!</SpeechBubble>
+      {userList?.map((item) => (
+        <User rank={item.rank} key={item.userId} nickname={item.name} />
       ))}
     </Container>
   );

--- a/src/components/MyPage/Calendar.jsx
+++ b/src/components/MyPage/Calendar.jsx
@@ -4,17 +4,32 @@ import {
   StyledToday,
   StyledDot,
 } from "../../styles/CalendarStyle";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import dayjs from "dayjs";
+import useFetchData from "../../hooks/useFetchData";
 
 export default function Challender() {
   const today = new Date();
   const [date, setDate] = useState(today);
 
-  const attendDay = ["2024-07-03", "2024-07-02"]; // 출석한 날짜 예시
+  // 출석한 날짜 저장할 state
+  const [attendDay, setAttendDay] = useState([]);
+
+  // 출석한 날짜 데이터 가져오기
+  const { data, isLoading } = useFetchData("/attendance/dates");
+
   const handleDateChange = (newDate) => {
     setDate(newDate);
   };
+
+  // 출석한 날짜 저장
+  useEffect(() => {
+    if (data) {
+      setAttendDay(data.map((item) => item.presentDate));
+    }
+  }, [data]);
+
+  if (isLoading) return "Loading...";
 
   return (
     <StyledCalendarWrapper>

--- a/src/components/MyPage/Circle.jsx
+++ b/src/components/MyPage/Circle.jsx
@@ -1,9 +1,24 @@
 import styled from "styled-components";
 import { RowContainer } from "../../styles/GlobalStyle";
 import CircleChart from "./CircleChart";
-
+import useFetchData from "../../hooks/useFetchData";
+import { useEffect, useState } from "react";
 export default function Circle() {
   const month = new Date().getMonth() + 1;
+
+  const [rate, setRate] = useState(0);
+
+  // 한 달 동안 몇일 출석했는 지 데이터 받아오기
+  const { data, isLoading } = useFetchData("/attendance/monthly-count");
+
+  useEffect(() => {
+    if (data) {
+      // 해당 달의 총 일수 구하기
+      let totalDay = new Date().getDate();
+      // 비율 구하기 (소수점 버림)
+      setRate(Math.floor((data[0].count / totalDay) * 100));
+    }
+  }, [data]);
 
   return (
     <RowContainer
@@ -19,10 +34,9 @@ export default function Circle() {
     >
       <H2>
         {month}월 한달 중<br />
-        N% 출석했어요!
+        {rate}% 출석했어요!
       </H2>
-
-      <CircleChart />
+      <CircleChart rate={rate} />
     </RowContainer>
   );
 }

--- a/src/components/MyPage/CircleChart.jsx
+++ b/src/components/MyPage/CircleChart.jsx
@@ -1,19 +1,20 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { RadialBarChart, RadialBar, ResponsiveContainer } from "recharts";
 import styled from "styled-components";
 
-const data = [
-  {
-    uv: 100,
-    fill: "black",
-  },
-  {
-    uv: 70, // 원하는 퍼센트 값으로 설정
-    fill: "#7D7AFF",
-  },
-];
+export default function CircleChart({ rate }) {
+  // 도넛 모양 차트에 표현하기 위한 기본적인 데이터로 초기화
+  const [data, setData] = useState([{ uv: 100, fill: "black" }]);
 
-export default function CircleChart() {
+  // 부모 컴포넌트에서 받은 rate를 이용하여 차트에 표시하기
+  useEffect(() => {
+    if (rate) {
+      let arr = [...data];
+      arr[1] = { uv: rate, fill: "#7D7AFF" };
+      setData(arr);
+    }
+  }, [rate]);
+
   return (
     <CircleWrap>
       <ResponsiveContainer width="100%" height="100%">

--- a/src/components/MyPage/MyChallengeList.jsx
+++ b/src/components/MyPage/MyChallengeList.jsx
@@ -9,6 +9,12 @@ const challengeList = [
 ];
 
 export default function MyChallengeList() {
+  // const { data, isLoading, error } = useFecthData(
+  //   "/challengeparticipant/completed-month-challenges"
+  // );
+
+  // console.log(data, error);
+
   return (
     <div>
       {challengeList.map((item, idx) => (

--- a/src/components/MyPage/MyChallengeList.jsx
+++ b/src/components/MyPage/MyChallengeList.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Challenge from "../Main/Challenge";
+import useFecthData from "../../hooks/useFetchData";
 
 const challengeList = [
   { content: "30분 이상 운동하기" },

--- a/src/store/useChallenge.jsx
+++ b/src/store/useChallenge.jsx
@@ -1,0 +1,9 @@
+import { create } from "zustand";
+
+export const useChallenge = create((set) => ({
+  list: [],
+  setList: (newList) =>
+    set(() => ({
+      list: newList,
+    })),
+}));


### PR DESCRIPTION
## 구현한 것
1. 메인화면 챌린지 api 연동
2. 메인화면 사용자 순위 api 연동
3. 마이페이지 출석 api 연동

## 설명
- 체크 버튼 눌렀을 때 챌린지 완료, 취소를 수행할 함수 구현
- 로직이 반복되는 부분이 있는 거 같아 함수로 분리하려 했지만 오류가 자꾸 발생하여 실패했습니다ㅜㅜ
```javascript
// 챌린지 완료 모양 눌럿을 때 실행할 함수
  const handleCheck = async (idx, id) => {
    // 모든 챌린지 완료했으면 챌린지 완료 표시 수정 불가능
    if (allComplete) {
      return;
    }
    // 체크 모양 눌렀을 때 해당 챌린지 취소, 완료 표시하기
    let arr = [...challengeList];

    // 해당 챌린지가 완료인 경우 false로 바꾸기
    if (arr[idx].completed) {
      // 사용자에게 미리 업데이트
      arr[idx].completed = false;
      // 서버로 데이터 전송
      try {
        await api.put(`/challengeparticipant/notcomplete/${id}`);
      } catch (e) {
        console.error("에러 발생 " + e);
      }
    } else {
      // 미완료 챌린지를 클릭한 경우 true로 변경
      arr[idx].completed = true;
      try {
        await api.put(`/challengeparticipant/complete/${id}`);
      } catch (e) {
        console.error("에러 발생: ", e);
      }
    }

    //상태 업데이트
    setChallengeList(arr);

    // 챌린지가 모두 완료되었으면 allComplete 상태 변경
    if (arr.every((item) => item.completed)) {
      setAllComplete(true);
    }
  };
```
## 이슈
- useChallenge는 나중에 challenge 데이터 저장하려고 생성했는데 지금은 무시 하셔도 됩니다