### PR TITLE
feat : 마이페이지 친구 검색 + 친구 요청 api 연동 완료 + 짜잘한 것들 수정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -122,7 +122,14 @@ function App() {
             </ProtectedRouter>
           }
         />
-        <Route path="/alarm" element={<Alaram />} />
+        <Route
+          path="/alarm"
+          element={
+            <ProtectedRouter>
+              <Alaram />
+            </ProtectedRouter>
+          }
+        />
       </Routes>
     </>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ import ForgetPW from "./pages/ForgetPW";
 import SignUp from "./pages/SignUp";
 import Community from "./pages/Community";
 import DetailBoard from "./pages/DetailBoard";
-import Main from "./pages/main";
+import Main from "./pages/Main";
 import EditUserInfo from "./pages/EditUserInfo";
 import PlayList from "./pages/PlayList";
 import MyPage from "./pages/MyPage";

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -23,7 +23,7 @@ export default function BottomNav() {
       </div>
       {/* 채팅이동 */}
       <div>
-        <Link>
+        <Link to="/posts">
           <StyledIcon as={MdOutlineChat} />
         </Link>
       </div>
@@ -32,7 +32,6 @@ export default function BottomNav() {
 }
 
 //================================================================================
-
 
 const StyledIcon = styled.div`
   width: ${responsiveSize("38")};

--- a/src/components/FriendList/AddUserList.jsx
+++ b/src/components/FriendList/AddUserList.jsx
@@ -1,6 +1,11 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { User } from "./User";
+import { MainH3 } from "../../styles/GlobalStyle";
 import user from "../../images/user.png";
+import { usePostData } from "../../hooks/usePostData";
+import { useFriendSearchStore } from "../../store/useFriendSearchStore";
+import styled from "styled-components";
+
 // mock 데이터 ( 서버에서 검색한 값 가져오기 )
 const userList = [
   { id: 1, nickname: "zoedhj", image: user },
@@ -16,18 +21,63 @@ const userList = [
   { id: 11, nickname: "lymuo", image: user },
 ];
 export const AddUserList = () => {
-  // 친구 추가 버튼 눌렀을 때 실행할 함수
+  // 유저 정보 담을 state
+  const [userList, setUserList] = useState([]);
+
+  // 검색 값 저장할 value
+  const { value, setValue } = useFriendSearchStore();
+
+  // 친구 검색 요청할 post 함수 가져오기
+  const { data, isLoading, postData } = usePostData("/friends/non-friends");
+
+  // 친구 검색 api 연동 입력값이 없을 때는 빈 배열로 초기화
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      // 검색 값이 빈 문자열이 아닌 경우 실행
+      if (value !== "") {
+        await postData({ searchName: value });
+        if (data) {
+          setUserList(data);
+        }
+      } else {
+        // 검색 값이 빈 문자열인 경우 빈배열로 초기화
+        setUserList([]);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [value]);
+
+  // 첫 랜더링 시 inpurt 검색값 빈 문자열로 초기화
+  useEffect(() => {
+    setValue("");
+  }, []);
+
+  // 아무것도 입력하지 않았을 때 랜더링
+  if (value === "") return <P>친구 닉네임을 입력하세요!</P>;
+
+  // 로딩중이면 로딩중이라고 띄우기
+  if (isLoading) return <P>Loading...</P>;
 
   return (
     <div>
-      {userList?.map((item) => (
-        <User
-          key={item.id}
-          id={item.id}
-          nickname={item.nickname}
-          image={item.image}
-        />
-      ))}
+      {userList?.length === 0 ? (
+        <P>검색 결과가 없습니다.</P>
+      ) : (
+        userList?.map((item) => (
+          <User
+            key={item.id}
+            id={item.id}
+            nickname={item.name}
+            image={item.profileUrl ?? user}
+          />
+        ))
+      )}
     </div>
   );
 };
+
+const P = styled.p`
+  margin-top: 20px;
+  color: ${({ theme }) => theme.colors.gray02};
+`;

--- a/src/components/FriendList/AddUserList.jsx
+++ b/src/components/FriendList/AddUserList.jsx
@@ -6,20 +6,6 @@ import { usePostData } from "../../hooks/usePostData";
 import { useFriendSearchStore } from "../../store/useFriendSearchStore";
 import styled from "styled-components";
 
-// mock 데이터 ( 서버에서 검색한 값 가져오기 )
-const userList = [
-  { id: 1, nickname: "zoedhj", image: user },
-  { id: 2, nickname: "ywamcgj", image: user },
-  { id: 3, nickname: "qmbvsz", image: user },
-  { id: 4, nickname: "xpjaf", image: user },
-  { id: 5, nickname: "gftrwb", image: user },
-  { id: 6, nickname: "utdjlg", image: user },
-  { id: 7, nickname: "ekzn", image: user },
-  { id: 8, nickname: "bnqozga", image: user },
-  { id: 9, nickname: "vjocb", image: user },
-  { id: 10, nickname: "hwxdp", image: user },
-  { id: 11, nickname: "lymuo", image: user },
-];
 export const AddUserList = () => {
   // 유저 정보 담을 state
   const [userList, setUserList] = useState([]);
@@ -35,9 +21,9 @@ export const AddUserList = () => {
     const timer = setTimeout(async () => {
       // 검색 값이 빈 문자열이 아닌 경우 실행
       if (value !== "") {
-        await postData({ searchName: value });
-        if (data) {
-          setUserList(data);
+        let postdata = await postData({ searchName: value });
+        if (postdata) {
+          setUserList(postdata);
         }
       } else {
         // 검색 값이 빈 문자열인 경우 빈배열로 초기화

--- a/src/components/FriendList/User.jsx
+++ b/src/components/FriendList/User.jsx
@@ -4,11 +4,17 @@ import styled, { keyframes } from "styled-components";
 import { FaRegTrashAlt } from "react-icons/fa";
 import { FaPlus } from "react-icons/fa6";
 import { FaCheck } from "react-icons/fa";
+import { usePostData } from "../../hooks/usePostData";
 
 // type으로 친구 추가할지 삭제할지 설정
 export const User = ({ id, nickname, image, type, onClick }) => {
   // 친구 추가 버튼을 눌렀는지 확인하는 state (친구 추가 버튼을 누르면 + 버튼이 안 보여야됨)
   const [isPlused, setIsPlused] = useState(false);
+
+  //
+  const { data, isLoading, error, postData } = usePostData(
+    `/friends/request/${id}`
+  );
 
   // 친구 추가 버튼 눌렀을 때 실행할 함수
   const handlePlusButton = () => {
@@ -18,6 +24,7 @@ export const User = ({ id, nickname, image, type, onClick }) => {
     }
     setIsPlused(true);
     // 서버에게 친구 추가 api 요청
+    postData();
   };
 
   return (

--- a/src/components/FriendList/UserList.jsx
+++ b/src/components/FriendList/UserList.jsx
@@ -16,7 +16,7 @@ export const UserList = () => {
   const [searchUser, setSearchUser] = useState(null);
 
   // input값 가져오기
-  const { value } = useFriendSearchStore();
+  const { value, setValue } = useFriendSearchStore();
 
   // 친구 수 저장할 함수 가져오기
   const { setNum } = useFriendNumStore();
@@ -66,6 +66,10 @@ export const UserList = () => {
 
     return () => clearTimeout(timer);
   }, [value, data, users]);
+
+  useEffect(() => {
+    setValue("");
+  }, []);
 
   // 서버에서 데이터 받아오는 중이면 Loading 출력
   if (isLoading) return "Loading...";

--- a/src/components/Main/ChallengeList.jsx
+++ b/src/components/Main/ChallengeList.jsx
@@ -16,6 +16,9 @@ export default function ChallengeList() {
   // 챌린지 3개 가져오기
   const { data } = useFetchData("/challengeparticipant/today-challenges");
 
+  // const { data: total } = useFetchData("/completed-friend-count");
+  // console.log(total);
+
   // 챌린지 완료 모양 눌럿을 때 실행할 함수
   const handleCheck = async (idx, id) => {
     // 모든 챌린지 완료했으면 챌린지 완료 표시 수정 불가능
@@ -57,6 +60,7 @@ export default function ChallengeList() {
   // 챌린지 가져오고 state에 저장
   useEffect(() => {
     if (data) {
+      console.log(data);
       setChallengeList(data);
       setAllComplete(data.length === 3 && data.every((item) => item.completed));
     }

--- a/src/components/Main/ChallengeList.jsx
+++ b/src/components/Main/ChallengeList.jsx
@@ -16,8 +16,10 @@ export default function ChallengeList() {
   // 챌린지 3개 가져오기
   const { data } = useFetchData("/challengeparticipant/today-challenges");
 
-  const { data: total } = useFetchData("/completed-friend-count");
-  console.log(total);
+  // 오늘의 챌린지 완료한 친구 수 가져오기
+  const { data: total } = useFetchData(
+    "/challengeparticipant/completed-friend-count"
+  );
 
   // 챌린지 완료 모양 눌럿을 때 실행할 함수
   const handleCheck = async (idx, id) => {
@@ -68,7 +70,7 @@ export default function ChallengeList() {
 
   return (
     <Container>
-      <SpeechBubble>친구 27명이 성공했어요!</SpeechBubble>
+      <SpeechBubble>친구 {total ?? 0}명이 성공했어요!</SpeechBubble>
       {challengeList?.map((item, idx) => (
         <Challenge
           allComplete={allComplete}

--- a/src/components/Main/ChallengeList.jsx
+++ b/src/components/Main/ChallengeList.jsx
@@ -16,8 +16,8 @@ export default function ChallengeList() {
   // 챌린지 3개 가져오기
   const { data } = useFetchData("/challengeparticipant/today-challenges");
 
-  // const { data: total } = useFetchData("/completed-friend-count");
-  // console.log(total);
+  const { data: total } = useFetchData("/completed-friend-count");
+  console.log(total);
 
   // 챌린지 완료 모양 눌럿을 때 실행할 함수
   const handleCheck = async (idx, id) => {

--- a/src/components/MyPage/MyChallengeList.jsx
+++ b/src/components/MyPage/MyChallengeList.jsx
@@ -1,31 +1,46 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Challenge from "../Main/Challenge";
-import useFecthData from "../../hooks/useFetchData";
-
-const challengeList = [
-  { content: "30분 이상 운동하기" },
-  { content: "물 2L 이상 마시기" },
-  { content: "헬스장 가기" },
-];
+import { useChallenge } from "../../store/useChallenge";
+import { usePostData } from "../../hooks/usePostData";
 
 export default function MyChallengeList() {
-  // const { data, isLoading, error } = useFecthData(
-  //   "/challengeparticipant/completed-month-challenges"
-  // );
+  const year = new Date().getFullYear();
+  const month = new Date().getMonth() + 1;
 
-  // console.log(data, error);
+  const { list3, setList, setCount, setList3 } = useChallenge();
+
+  const { data, isLoading, error, postData } = usePostData(
+    "/challengeparticipant/completed-month-challenges"
+  );
+
+  useEffect(() => {
+    if (data) {
+      console.log(data);
+      let arr = data.challenges.filter((item, idx) => idx <= 2);
+      console.log(arr);
+
+      setList(data.challenges);
+      setCount(data.challenges.length);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    postData({ year, month });
+  }, []);
 
   return (
     <div>
-      {challengeList.map((item, idx) => (
-        <Challenge
-          key={idx}
-          index={idx + 1}
-          content={item.content}
-          complete={true}
-          handleCheck={() => {}}
-        />
-      ))}
+      {list3.length === 0
+        ? "완료한 챌린지가 없습니다!"
+        : list3.map((item) => (
+            <Challenge
+              key={item.challengeId}
+              index={item.challengeId}
+              content={item.challengeContent}
+              complete={true}
+              handleCheck={() => {}}
+            />
+          ))}
     </div>
   );
 }

--- a/src/components/MyPage/Videos.jsx
+++ b/src/components/MyPage/Videos.jsx
@@ -20,5 +20,6 @@ export default function Videos() {
     });
     setVideoIds(arr);
   }, [data]);
+
   return <div>{videoIds && data && <VideoList videoIds={videoIds} />}</div>;
 }

--- a/src/hooks/usePostData.jsx
+++ b/src/hooks/usePostData.jsx
@@ -12,6 +12,7 @@ export const usePostData = (url) => {
     try {
       const res = await api.post(url, payload);
       setData(res.data);
+      return res.data;
     } catch (e) {
       setError(e);
     } finally {

--- a/src/hooks/usePostData.jsx
+++ b/src/hooks/usePostData.jsx
@@ -1,4 +1,4 @@
-import  { useState } from "react";
+import { useState } from "react";
 import api from "../apis/axios";
 
 export const usePostData = (url) => {
@@ -11,7 +11,6 @@ export const usePostData = (url) => {
 
     try {
       const res = await api.post(url, payload);
-      console.log(res);
       setData(res.data);
     } catch (e) {
       setError(e);

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -13,16 +13,25 @@ import PlayListList from "../components/Main/PlayListList";
 import ChallengeList from "../components/Main/ChallengeList";
 import UserList from "../components/Main/UserList";
 import BottomNav from "../components/BottomNav";
+import { useNavigate } from "react-router-dom";
 
 export default function Main() {
   const today = new Date();
+
+  const nav = useNavigate();
 
   return (
     <MainWrapper>
       <MainContainer>
         <MainContent>
           {/* 헤더 내비 게이션 */}
-          <Header type={"alarm"} size={"30"} />
+          <Header
+            type={"alarm"}
+            size={"30"}
+            onClick={() => {
+              nav("/alarm");
+            }}
+          />
           <MainH2>
             사용자님!
             <br />

--- a/src/store/useChallenge.jsx
+++ b/src/store/useChallenge.jsx
@@ -1,9 +1,19 @@
 import { create } from "zustand";
 
 export const useChallenge = create((set) => ({
+  count: 0,
   list: [],
+  list3: [],
+  setList3: (newList) =>
+    set(() => ({
+      list3: newList,
+    })),
   setList: (newList) =>
     set(() => ({
       list: newList,
+    })),
+  setCount: (count) =>
+    set(() => ({
+      count: count,
     })),
 }));


### PR DESCRIPTION
## 구현한 것

https://github.com/user-attachments/assets/cec6ed1c-8550-4bee-a3c1-e13a47d1b7d2


1. 친구 검색 api 연동하였습니다
```javascript
  // 친구 검색 api 연동 입력값이 없을 때는 빈 배열로 초기화
  useEffect(() => {
    const timer = setTimeout(async () => {
      // 검색 값이 빈 문자열이 아닌 경우 실행
      if (value !== "") {
// 서버에서 받아온 값으로 userList 업데이트
        let postdata = await postData({ searchName: value });
        if (postdata) {
          setUserList(postdata);
        }
      } else {
        // 검색 값이 빈 문자열인 경우 빈배열로 초기화
        setUserList([]);
      }
    }, 500);
```
2. 친구 추가 버튼 눌렀을 때 api 연동했습니다
3. BottomNav에서 맨 오른쪽 메신저 버튼 누르면 /posts로 이동되도록 하였습니다
4. 메인화면의 header에서 알람 아이콘 클릭하면 알림 화면으로 이동하도록 하였습니다.
5. 알림 화면 protected router 사용했습니다

## 이슈
AddUserList, User 파일만 보면 됩니다!

챌린지 쪽은 하다가 api 오류 있어서 api 수정중이라 완료되는대로 진행하겠습니다~  