### PR TITLE
fix: 회원가입 페이지 운동시간 분 단위로 변경

### DIFF
--- a/src/components/Login/ForgetPwP1.jsx
+++ b/src/components/Login/ForgetPwP1.jsx
@@ -99,7 +99,7 @@ export default function ForgetPwP1({email, setEmail, swiperRef}) {
                             ></MyInput>
                         <ValidButton
                             onClick={handleAuthCodeCheck}
-                            disabled={!authCode}
+                            disabled={!authCode || authCodeValid}
                         >
                             확인
                         </ValidButton>

--- a/src/components/Login/ForgetPwP2.jsx
+++ b/src/components/Login/ForgetPwP2.jsx
@@ -52,7 +52,7 @@ export default function ForgetPwP2({email}) {
         try {
             await resetPassword(email, password);
             alert("비밀번호가 성공적으로 변경되었습니다.");
-            setTimeout(() => navigate('/'), 2000); // 2초 후 로그인 페이지로 이동
+            navigate('/'); // 로그인 페이지로 이동
         } catch (error) {
             console.error(error)
             alert("비밀번호 재설정에 실패했습니다. 다시 시도해주세요.");

--- a/src/components/SignUp/Page3.jsx
+++ b/src/components/SignUp/Page3.jsx
@@ -84,7 +84,7 @@ export default function Page3 () {
         targetWeight: parseFloat(formData.targetWeight),
         date: formData.date,
         targetDate: formData.targetDate,
-        exerciseTime: parseInt(formData.exerciseTime),
+        exerciseTime: parseInt(formData.exerciseTime)*60, //시간으로 받은 데이터 값 -> 분 단위로 변경
         exerciseIntensity: setCategory["exerciseIntensity"],
         exerciseGoals: setCategory["exerciseGoals"],
         concernedAreas: setCategory["concernedAreas"],


### PR DESCRIPTION
- 서연님이 운동시간 입력값을 분 단위로 바꿔달라고 하셔서 그 부분 변경했습니다. (signup.jsx > page3.jsx > initialForm 변경)
- PW찾기 페이지에서 비밀번호 변경 기능도 확인했는데 잘 적용됩니다! 
다만, 기존 비밀번호와 변경할 비밀번호가 같을 때도 변경이 되었다고 알림창이 뜹니다.
```javascript
exerciseTime: parseInt(formData.exerciseTime)*60, //시간으로 받은 데이터 값 -> 분 단위로 변경
```